### PR TITLE
Update Homebrew installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Install dfu-util from your disto's package manager.
 Install via brew cask (this will automatically install the dfu-util dependency)
 
 ```bash
+$ brew tap caskroom/drivers
 $ brew cask install kiibohd-configurator
 ```
 


### PR DESCRIPTION
Cask was moved to caskroom/drivers (see caskroom/homebrew-cask#40398) but current docs don't include the `brew tap` step.

Fixes #50 