### PR TITLE
Add shortcut to clear assignment

### DIFF
--- a/src/renderer/configure/key-info.tsx
+++ b/src/renderer/configure/key-info.tsx
@@ -87,7 +87,9 @@ export default function KeyInfo() {
         <div className={classes.message}>
           <Typography variant="subtitle1">No key currently selected</Typography>
           <br />
-          <Typography variant="body2">You can use Shift + Left Mouse to quick assign</Typography>
+          <Typography variant="body2">
+            You can use Shift + Left Mouse to quick assign and Ctrl + Left Mouse to clear an assignment.
+          </Typography>
         </div>
       )}
       {selected && (

--- a/src/renderer/configure/onscreen-keyboard.tsx
+++ b/src/renderer/configure/onscreen-keyboard.tsx
@@ -155,6 +155,8 @@ export default function OnScreenKeyboard() {
   const mouseClick = (e: React.MouseEvent, key: ConfigMatrixItem) => {
     if (e.shiftKey) {
       setQuickAssignKey(key);
+    } else if (e.ctrlKey) {
+      updateKeymap(key, null);
     } else {
       setSelected(key === selected ? undefined : key);
     }


### PR DESCRIPTION
Removing things you don't want from the standard layouts is slow and painful right now. This adds a Ctrl + click shortcut to make it much faster.